### PR TITLE
5.x

### DIFF
--- a/YSI_Coding/y_unique/y_unique_entry.inc
+++ b/YSI_Coding/y_unique/y_unique_entry.inc
@@ -141,6 +141,10 @@ Optional plugins:
 #endif
 
 #if defined YSI_LOCK_MODE
+	#if !defined YSI_gLockData
+	    new
+			YSI_gLockData[21];
+	#endif
 	#if Y_UNIQUE_LOCK_CONTRIBUTION < 2
 		forward UNIQUE_FUNCTION<@yH_OnScriptInit@...>();
 		

--- a/YSI_Coding/y_unique/y_unique_entry.inc
+++ b/YSI_Coding/y_unique/y_unique_entry.inc
@@ -141,13 +141,9 @@ Optional plugins:
 #endif
 
 #if defined YSI_LOCK_MODE
-	#if !defined YSI_gLockData
-	    new
-			YSI_gLockData[21];
-	#endif
 	#if Y_UNIQUE_LOCK_CONTRIBUTION < 2
 		forward UNIQUE_FUNCTION<@yH_OnScriptInit@...>();
-		
+
 		public UNIQUE_FUNCTION<@yH_OnScriptInit@...>()
 		{
 			#if Y_UNIQUE_LOCK_CONTRIBUTION == 0
@@ -160,7 +156,7 @@ Optional plugins:
 				YSI_gLockData{11} = 0;
 			#endif
 		}
-		
+
 		#include "y_unique_entry"
 	#endif
 #endif

--- a/YSI_Core/y_master/y_distribute.inc
+++ b/YSI_Core/y_master/y_distribute.inc
@@ -162,7 +162,7 @@ stock Distribute_Do(func[], GLOBAL_TAG_TYPES:...)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-stock Distribute_So(func[], idx, Bit:masters[], GLOBAL_TAG_TYPES:...)
+stock Distribute_So(func[], idx, const Bit:masters[], GLOBAL_TAG_TYPES:...)
 {
 	new
 		m = _:masters[idx] & ~Master_ID();

--- a/YSI_Core/y_master/y_master_once.inc
+++ b/YSI_Core/y_master/y_master_once.inc
@@ -521,7 +521,7 @@ public Master_Reassert()
 	#endinput
 #endif
 
-stock _Master_Relinquish(library[])
+stock _Master_Relinquish(const library[])
 {
 	//printf("STEAL %s %d", library, YSI_g_sMasterCount);
 	switch (YSI_g_sMasterCount)
@@ -552,7 +552,7 @@ stock _Master_Relinquish(library[])
  * <param name="library">The name of the library to try become master for.</param>
  *//*------------------------------------------------------------------------**/
 
-stock bool:_Master_Get(library[], bool:force = false)
+stock bool:_Master_Get(const library[], bool:force = false)
 {
 	new
 		bool:ret = true;

--- a/YSI_Data/y_playerarray/y_playerarray_entry.inc
+++ b/YSI_Data/y_playerarray/y_playerarray_entry.inc
@@ -138,7 +138,7 @@ stock PA_Set(PlayerArray:d<>, slot, bool:set)
 	}
 }
 
-stock Iter_Func@PA(start, PlayerArray:data<>)
+stock Iter_Func@PA(start, const PlayerArray:data<>)
 {
 	P:3("YSI_gAPAFunc called: %s, %i", Bit_Display(Bit:data[1]), start);
 	++start;

--- a/YSI_Players/y_groups/y_groups__funcs.inc
+++ b/YSI_Players/y_groups/y_groups__funcs.inc
@@ -559,7 +559,7 @@ GGLOBAL__ Group_GlobalExclusive...(_GROUP_MAKE_TAG:el)
 
 */
 
-static stock void:Group_Handoff(i,a[],s)
+static stock void:Group_Handoff(i,const a[],s)
 {
 	s = min(s, bits<_:_MAX_GROUPS_G>);
 	if (i == -1)
@@ -604,7 +604,7 @@ MASTER_FUNC__ MAKE_YCM<HANDOFF_SOURCE...Group>()<_YCM:p>
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-static stock Group_FullPlayerUpdate(playerid, el, Bit:p[], Bit:c[], Bit:r[])
+static stock Group_FullPlayerUpdate(playerid, el, const Bit:p[], const Bit:c[], const Bit:r[])
 {
 	// "_GROUPS_CHECK" is a macro that expands to a massive unrolled "if"
 	// statement checking up to 512 groups at once.  Any more than that and this

--- a/YSI_Players/y_groups/y_groups_impl.inc
+++ b/YSI_Players/y_groups/y_groups_impl.inc
@@ -379,7 +379,7 @@ public OnScriptExit()
  * <param name="group">Group to destroy from the system.</param>
  *//*------------------------------------------------------------------------**/
 
-remotefunc static void:_Group_Destroy(g, Iterator@gp[MAX_PLAYERS + 1], s)
+remotefunc static void:_Group_Destroy(g, const Iterator@gp[MAX_PLAYERS + 1], s)
 {
 	#pragma unused s
 	new
@@ -740,9 +740,9 @@ remotefunc void:_Group_SetPlayer(p, Bit:g[sizeof RG@], s)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Group:_Group_SetBalancedInternal(p,Group:gs[],c);
+FOREIGN__ Group:_Group_SetBalancedInternal(p,const Group:gs[],c);
 
-GLOBAL__ Group:_Group_SetBalancedInternal(p,Group:gs[],c)
+GLOBAL__ Group:_Group_SetBalancedInternal(p,const Group:gs[],c)
 {
 	// Find which of the listed groups has the least players in.
 	new
@@ -884,9 +884,9 @@ stock bool:operator!=(Group:g, o)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ void:Group_SetName(Group:g,string:n[]);
+FOREIGN__ void:Group_SetName(Group:g,const string:n[]);
 
-GLOBAL__ void:Group_SetName(Group:g,string:n[])
+GLOBAL__ void:Group_SetName(Group:g,const string:n[])
 {
 	P:2("Group_SetName called: %i, \"%s\"", _:g, n);
 	if (_Group_IsValid(g))
@@ -942,9 +942,9 @@ GLOBAL__ string:Group_GetName(Group:g)
  * </returns>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Group:Group_GetID(string:name[]);
+FOREIGN__ Group:Group_GetID(const string:name[]);
 
-GLOBAL__ Group:Group_GetID(string:name[])
+GLOBAL__ Group:Group_GetID(const string:name[])
 {
 	P:2("Group_GetID called: %s", name);
 	new

--- a/YSI_Players/y_languages/y_languages_entry.inc
+++ b/YSI_Players/y_languages/y_languages_entry.inc
@@ -260,9 +260,9 @@ GLOBAL__ void:Langs_RemoveLanguage(Language:l)
  * <summary>-</summary>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Language:Langs_GetLanguage(string:identifier[]);
+FOREIGN__ Language:Langs_GetLanguage(const string:identifier[]);
 
-GLOBAL__ Language:Langs_GetLanguage(string:identifier[])
+GLOBAL__ Language:Langs_GetLanguage(const string:identifier[])
 {
 	if (strlen(identifier) > 2)
 	{
@@ -392,9 +392,9 @@ GLOBAL__ Language:Langs_SetPlayerLanguage(playerid, Language:l)
  * <summary>-</summary>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Language:Langs_SetPlayerCode(playerid, string:code[]);
+FOREIGN__ Language:Langs_SetPlayerCode(playerid, const string:code[]);
 
-GLOBAL__ Language:Langs_SetPlayerCode(playerid, string:code[])
+GLOBAL__ Language:Langs_SetPlayerCode(playerid, const string:code[])
 {
 	return Langs_SetPlayerLanguage(playerid, Langs_GetLanguage(code));
 }

--- a/YSI_Players/y_text/y_text_impl.inc
+++ b/YSI_Players/y_text/y_text_impl.inc
@@ -110,7 +110,7 @@ enum e_TEXT_DISPLAY_TYPE:
 	loadtext core[%1]
 
 // Clever macros to load default values when not specified.
-//#define Text_Send(%0,%1) _Text_Send(%0,DEFAULT_TEXT_SET,#%1)
+#define Text_Send(%0,%1) _Text_Send(%0,DEFAULT_TEXT_SET,#%1)
 
 #define DO_TEXT_SET: _:HAS_TEXT_SET:NO_TEXT_SET:
 
@@ -296,7 +296,7 @@ static stock Text_LoadAll()
 /*-------------------------------------------------------------------------*//**
  *//*------------------------------------------------------------------------**/
 
-static stock Text_AddLocal(buffer[])
+static stock Text_AddLocal(const buffer[])
 {
 	P:4("Text_AddLocal called: \"%s\", %i", buffer);
 	// Check if this already exists.  If not, add it to a found free slot.
@@ -569,6 +569,8 @@ static stock Text_LoadLocals()
 
 stock _Text_CheckOwnership(file[], str[])
 {
+	#pragma unused file
+	#pragma unused str
 	// TODO...
 //	P:4("_Text_CheckOwnership called: %s, %s", file, str);
 //	format(YSI_g_sReturnText, sizeof (YSI_g_sReturnText), "%s:%s", file, str);
@@ -591,6 +593,7 @@ stock _Text_CheckOwnership(file[], str[])
 
 stock _Text_LookupName(name[])
 {
+    #pragma unused name
 	// TODO...
 //	P:4("_Text_LookupName called: %s, %s", name, YSI_g_sReturnText);
 //	new
@@ -933,7 +936,7 @@ static stock Text_GetFreeEntry()
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-static stock Text_IsLocalOwner(search[], ident[], &len)
+static stock Text_IsLocalOwner(search[], const ident[], &len)
 {
 	// First, find out if this script owns it's own text for speed reasons, and
 	// if it does, save the handle to the text set.

--- a/YSI_Players/y_text/y_text_impl.inc
+++ b/YSI_Players/y_text/y_text_impl.inc
@@ -110,7 +110,7 @@ enum e_TEXT_DISPLAY_TYPE:
 	loadtext core[%1]
 
 // Clever macros to load default values when not specified.
-#define Text_Send(%0,%1) _Text_Send(%0,DEFAULT_TEXT_SET,#%1)
+//#define Text_Send(%0,%1) _Text_Send(%0,DEFAULT_TEXT_SET,#%1)
 
 #define DO_TEXT_SET: _:HAS_TEXT_SET:NO_TEXT_SET:
 
@@ -569,8 +569,6 @@ static stock Text_LoadLocals()
 
 stock _Text_CheckOwnership(file[], str[])
 {
-	#pragma unused file
-	#pragma unused str
 	// TODO...
 //	P:4("_Text_CheckOwnership called: %s, %s", file, str);
 //	format(YSI_g_sReturnText, sizeof (YSI_g_sReturnText), "%s:%s", file, str);
@@ -593,7 +591,6 @@ stock _Text_CheckOwnership(file[], str[])
 
 stock _Text_LookupName(name[])
 {
-    #pragma unused name
 	// TODO...
 //	P:4("_Text_LookupName called: %s, %s", name, YSI_g_sReturnText);
 //	new

--- a/YSI_Players/y_text/y_text_render.inc
+++ b/YSI_Players/y_text/y_text_render.inc
@@ -146,7 +146,7 @@ stock _Text_SetDialogMode()
 	YSI_g_sJustOne = true;
 }
 
-stock Format_SetListSeparator(string:lst[])
+stock Format_SetListSeparator(const string:lst[])
 {
 	strcpy(YSI_g_sListSep, lst);
 }
@@ -158,7 +158,7 @@ stock Format_SetListSeparator(string:lst[])
  * <transition keep="true" target="y_render_show : y_render_show_print" />
  *//*------------------------------------------------------------------------**/
 
-stock _Format_SetStyleData(master, index, style[E_STYLE_DATA], label[E_3D_DATA])
+stock _Format_SetStyleData(master, index, const style[E_STYLE_DATA], const label[E_3D_DATA])
 {
 	// =========================================================================
 	//  
@@ -815,22 +815,22 @@ static stock Format_DoDisplay(playerid, colour, out[]) <y_render_show : y_render
  * <param name="out">What the text to show is.</param>
  *//*------------------------------------------------------------------------**/
 
-stock Format_JustShow(playerid, out[]) <y_render_show : y_render_show_scm>
+stock Format_JustShow(playerid, const out[]) <y_render_show : y_render_show_scm>
 {
 	SendClientMessage(playerid, gInitialColour, out);
 }
 
-stock Format_JustShow(playerid, out[]) <y_render_show : y_render_show_print>
+stock Format_JustShow(playerid, const out[]) <y_render_show : y_render_show_print>
 {
 	P:0("Format_DoDisplay: %d, \"%s\"", playerid, out);
 }
 
-stock Format_JustShow(playerid, out[]) <y_render_show : y_render_show_gt>
+stock Format_JustShow(playerid, const out[]) <y_render_show : y_render_show_gt>
 {
 	GameTextForPlayer(playerid, out, YSI_g_sTempStyle[E_STYLE_DATA_TIME], YSI_g_sTempStyle[E_STYLE_DATA_STYLE]);
 }
 
-stock Format_JustShow(playerid, out[]) <y_render_show : y_render_show_td>
+stock Format_JustShow(playerid, const out[]) <y_render_show : y_render_show_td>
 {
 	TD_ShowForPlayer(playerid, Text:out[0]);
 }

--- a/YSI_Storage/y_php/y_php_entry.inc
+++ b/YSI_Storage/y_php/y_php_entry.inc
@@ -285,17 +285,17 @@ timer _PHP_FireOne[10](res, to)
 	HTTP(YSI_g_sID, HTTP_GET, sAddr, "", "_PHP_Result");
 }
 
-static stock PHP_GetNum32(str[])
+static stock PHP_GetNum32(const str[])
 {
 	return ((str[0] & ~0x80) << 25) | ((str[1] & ~0x80) << 18) | ((str[2] & ~0x80) << 11) | ((str[3] & ~0x80) << 4) | (str[4] & ~0xF0);
 }
 
-static stock PHP_GetNum8(str[])
+static stock PHP_GetNum8(const str[])
 {
 	return str[0] & ~0x80;
 }
 
-static stock PHP_GetNum6(str[])
+static stock PHP_GetNum6(const str[])
 {
 	return str[0] & ~0x40;
 }

--- a/YSI_Storage/y_svar/y_svar_ini.inc
+++ b/YSI_Storage/y_svar/y_svar_ini.inc
@@ -122,7 +122,7 @@ public _y_svar_include_@()
 	INI_WriteArray(INI_NO_FILE, "", "", 0);
 }
 
-static stock Svar_FindData(const name[], data[])
+static stock Svar_FindData(const name[], const data[])
 {
 	// This function gets passed an empty string so that we can use "data" as a
 	// string, while secretly changing the pointer in AMX code.

--- a/YSI_Visual/y_areas/y_areas_entry.inc
+++ b/YSI_Visual/y_areas/y_areas_entry.inc
@@ -1988,7 +1988,7 @@ MASTER_HOOK__ OnPlayerConnect(playerid)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-static stock Area_CheckArea(playerid, world, area, Float:x, Float:y, Float:z, &next, areas[16], already)
+static stock Area_CheckArea(playerid, world, area, Float:x, Float:y, Float:z, &next, const areas[16], already)
 {
 	new
 		e_AREA_FLAGS:flags = YSI_g_sAreas[area][E_AREA_FLAGS];
@@ -2077,7 +2077,7 @@ static stock Area_CheckArea(playerid, world, area, Float:x, Float:y, Float:z, &n
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-static stock Area_IsInCircle(Float:x, Float:y, Float:z, Float:bounds[])
+static stock Area_IsInCircle(Float:x, Float:y, Float:z, const Float:bounds[])
 {
 	x -= bounds[0];
 	y -= bounds[1];
@@ -2112,7 +2112,7 @@ static stock Area_IsInCircle(Float:x, Float:y, Float:z, Float:bounds[])
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-static stock Area_IsInOvoid(Float:x, Float:y, Float:z, Float:bounds[])
+static stock Area_IsInOvoid(Float:x, Float:y, Float:z, const Float:bounds[])
 {
 	x -= bounds[0];
 	y -= bounds[1];
@@ -2243,7 +2243,7 @@ stock Area_IsInPoly(Float:x, Float:y, Float:z, header)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-static stock Area_IsInCube(Float:x, Float:y, Float:z, Float:bounds[])
+static stock Area_IsInCube(Float:x, Float:y, Float:z, const Float:bounds[])
 {
 	return (bounds[0] <= x <= bounds[3] && bounds[1] <= y <= bounds[4] && bounds[2] <= z <= bounds[5]);
 }

--- a/YSI_Visual/y_classes/y_classes_multiclass.inc
+++ b/YSI_Visual/y_classes/y_classes_multiclass.inc
@@ -534,9 +534,9 @@ stock Class_AddWithGroupSet(Group:group, skin, Float:x, Float:y, Float:z, Float:
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Class_AddClass(s,Float:x,Float:y,Float:z,Float:a,w[],c,Group:f,Group:g);
+FOREIGN__ Class_AddClass(s,Float:x,Float:y,Float:z,Float:a,const w[],c,Group:f,Group:g);
 
-GLOBAL__ Class_AddClass(s,Float:x,Float:y,Float:z,Float:a,w[],c,Group:f,Group:g)
+GLOBAL__ Class_AddClass(s,Float:x,Float:y,Float:z,Float:a,const w[],c,Group:f,Group:g)
 {
 	#pragma unused c
 	P:2("Class_AddClass called: %i, %f, %f, %f, %f, %s, %i, %i, %i", s, x, y, z, a, Debug_PrintArray(w, c), c, _:f, _:g);

--- a/YSI_Visual/y_commands/y_commands_impl.inc
+++ b/YSI_Visual/y_commands/y_commands_impl.inc
@@ -358,9 +358,9 @@ P:D(Command_Name(f));
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Command_GetID(string:function[]);
+FOREIGN__ Command_GetID(const string:function[]);
 
-GLOBAL__ Command_GetID(string:function[])
+GLOBAL__ Command_GetID(const string:function[])
 {
 	P:2("Command_GetID called: \"%s\"", function);
 	return Command_Find(function);
@@ -374,9 +374,9 @@ GLOBAL__ Command_GetID(string:function[])
  * </returns>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Command_AddAlt(oidx, string:cmd[]);
+FOREIGN__ Command_AddAlt(oidx, const string:cmd[]);
 
-GLOBAL__ Command_AddAlt(oidx, string:cmd[])
+GLOBAL__ Command_AddAlt(oidx, const string:cmd[])
 {
 	static
 		sCmd[64],
@@ -642,9 +642,9 @@ GLOBAL__ bool:Command_GetPlayer(cmd, pid)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ bool:Command_GetPlayerNamed(string:func[], playerid);
+FOREIGN__ bool:Command_GetPlayerNamed(const string:func[], playerid);
 
-GLOBAL__ bool:Command_GetPlayerNamed(string:func[], playerid)
+GLOBAL__ bool:Command_GetPlayerNamed(const string:func[], playerid)
 {
 	return Command_GetPlayer(Command_Find(func), playerid);
 }
@@ -680,9 +680,9 @@ GLOBAL__ void:Command_SetPlayer(c, p, bool:s)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ void:Command_SetPlayerNamed(string:f[],p,bool:s);
+FOREIGN__ void:Command_SetPlayerNamed(const string:f[],p,bool:s);
 
-GLOBAL__ void:Command_SetPlayerNamed(string:f[],p,bool:s)
+GLOBAL__ void:Command_SetPlayerNamed(const string:f[],p,bool:s)
 {
 	Command_SetPlayer(Command_Find(f), p, s);
 }
@@ -695,9 +695,9 @@ GLOBAL__ void:Command_SetPlayerNamed(string:f[],p,bool:s)
  * </returns>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Command_Find(string:cmd[]);
+FOREIGN__ Command_Find(const string:cmd[]);
 
-GLOBAL__ Command_Find(string:cmd[])
+GLOBAL__ Command_Find(const string:cmd[])
 {
 	static
 		sCmd[64] = "",
@@ -718,9 +718,9 @@ GLOBAL__ Command_Find(string:cmd[])
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ void:Command_TouchNamed(string:command[]);
+FOREIGN__ void:Command_TouchNamed(const string:command[]);
 
-GLOBAL__ void:Command_TouchNamed(string:command[])
+GLOBAL__ void:Command_TouchNamed(const string:command[])
 {
 	new
 		id = Command_Find(command);
@@ -870,9 +870,9 @@ GLOBAL__ bool:Command_GetDisconnectReturn()
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ Command_AddAltNamed(string:function[], string:altname[]);
+FOREIGN__ Command_AddAltNamed(const string:function[], const string:altname[]);
 
-GLOBAL__ Command_AddAltNamed(string:function[], string:altname[])
+GLOBAL__ Command_AddAltNamed(const string:function[], const string:altname[])
 {
 	return Command_AddAlt(Command_Find(function), altname);
 }
@@ -910,9 +910,9 @@ GLOBAL__ void:Command_Remove(func)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ void:Command_RemoveNamed(string:func[]);
+FOREIGN__ void:Command_RemoveNamed(const string:func[]);
 
-GLOBAL__ void:Command_RemoveNamed(string:func[])
+GLOBAL__ void:Command_RemoveNamed(const string:func[])
 {
 	Command_Remove(Command_Find(func));
 }
@@ -1044,9 +1044,9 @@ GLOBAL__ string:Command_GetDisplay(funcid, playerid)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-FOREIGN__ string:Command_GetDisplayNamed(string:func[], playerid);
+FOREIGN__ string:Command_GetDisplayNamed(const string:func[], playerid);
 
-GLOBAL__ string:Command_GetDisplayNamed(string:func[], playerid)
+GLOBAL__ string:Command_GetDisplayNamed(const string:func[], playerid)
 {
 	return
 		_Command_GetDisplay(Command_Find(func), playerid),

--- a/YSI_Visual/y_properties/y_properties_entry.inc
+++ b/YSI_Visual/y_properties/y_properties_entry.inc
@@ -91,17 +91,28 @@ Optional plugins:
 	#define MAX_PROPERTIES 256
 #endif
 
-/*#if !defined GROUP_PROPERTY_BITS
+#if !defined MAX_CHECKPOINTS
+	#define MAX_CHECKPOINTS MAX_PROPERTIES
+#endif
+
+#if !defined GROUP_PROPERTY_BITS
 	#if MAX_PROPERTIES <= 32
 		#define GROUP_PROPERTY_BITS 2
 	#else
 		#define GROUP_PROPERTY_BITS Bit_Bits(MAX_PROPERTIES)
 	#endif
-#endif*/
+#endif
+
+#if !defined PLAYER_BIT_ARRAY
+	#define PLAYER_BIT_ARRAY Bit_Bits(MAX_PLAYERS)
+#endif
 
 #define NO_PROPERTY -1
+#define NO_CHECKPOINT -1
 
-#define WEAPON_ARMOUR 100
+#if !defined WEAPON_ARMOUR
+	#define WEAPON_ARMOUR 100
+#endif
 
 #define PROPERTY_SELL_PERCENT 60
 
@@ -907,7 +918,7 @@ Property_OnPlayerLeaveArea(playerid, area)
 HOOK__ OnPlayerConnect(playerid)
 {
 	YSI_g_sShopMenu[playerid][E_PROP_AMMU_MENU] = Menu:-1;
-	Bit_SetAll(YSI_g_sPlayerProperties[playerid], 0, GROUP_PROPERTY_BITS);
+	Bit_SetAll(YSI_g_sPlayerProperties[playerid], false, GROUP_PROPERTY_BITS);
 	for (new i = 0; i < 13; i++) YSI_g_sSpawnWeapons[playerid][i] = 0;
 	YSI_g_sMoney[playerid] = 0;
 	return 1;
@@ -922,26 +933,26 @@ HOOK__ OnPlayerConnect(playerid)
 
 HOOK__ OnPlayerDisconnect(playerid, reason)
 {
-	FOREACH__ (new prop : Bits(YSI_g_sPlayerProperties[playerid]))
+	FOREACH__ (new property : Bits(YSI_g_sPlayerProperties[playerid]))
 	{
 		new
-			e_PROP_FLAGS:flags = YSI_g_sProperties[prop][E_PROP_DATA_FLAGS];
+			e_PROP_FLAGS:flags = YSI_g_sProperties[property][E_PROP_DATA_FLAGS];
 		if (flags & e_PROP_FLAGS_ACTIVE)
 		{
 			if ((flags & e_PROP_FLAGS_TYPES) == e_PROP_FLAGS_TYPE_PROP)
 			{
 				if (Property_GetOption(2, flags))
 				{
-					if (_:Bit_GetBit(YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS], playerid))
+					if (_:Bit_GetBit(YSI_g_sProperties[property][E_PROP_DATA_PLAYERS], playerid))
 					{
-						Bit_Set(YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS], playerid, 0, PLAYER_BIT_ARRAY);
+						Bit_Set(YSI_g_sProperties[property][E_PROP_DATA_PLAYERS], playerid, false);//, PLAYER_BIT_ARRAY);
 					}
 				}
 				else
 				{
-					if (_:(YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS][0] == Bit:playerid))
+					if (_:(YSI_g_sProperties[property][E_PROP_DATA_PLAYERS][0] == Bit:playerid))
 					{
-						YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS][0] = Bit:INVALID_PLAYER_ID;
+						YSI_g_sProperties[property][E_PROP_DATA_PLAYERS][0] = Bit:INVALID_PLAYER_ID;
 					}
 				}
 				#pragma tabsize 4
@@ -955,9 +966,9 @@ HOOK__ OnPlayerDisconnect(playerid, reason)
 			}
 			else if ((flags & e_PROP_FLAGS_TYPES) == e_PROP_FLAGS_TYPE_HOUS)
 			{
-				if (_:(YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS][0] == Bit:playerid))
+				if (_:(YSI_g_sProperties[property][E_PROP_DATA_PLAYERS][0] == Bit:playerid))
 				{
-					YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS][0] = Bit:INVALID_PLAYER_ID;
+					YSI_g_sProperties[property][E_PROP_DATA_PLAYERS][0] = Bit:INVALID_PLAYER_ID;
 				}
 			}
 		}
@@ -994,7 +1005,7 @@ HOOK__ OnPlayerSpawn(playerid)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-HOOK__ OnPlayerLeaveCheckpointEx(playerid, cpid)
+HOOK__ OnPlayerLeaveCPEx(playerid, cpid)
 {
 	new
 		cp = YSI_g_sCheckpointPointers[cpid];
@@ -1007,7 +1018,7 @@ HOOK__ OnPlayerLeaveCheckpointEx(playerid, cpid)
 		type = _:(_:flags & _:e_PROP_FLAGS_TYPES);
 	if ((type != _:e_PROP_FLAGS_TYPE_HOUS || YSI_g_sProperties[cp][E_PROP_DATA_PLAYERS][0] != Bit:playerid) && (type != _:e_PROP_FLAGS_TYPE_PROP || !Property_IsOwner(playerid, cp, flags)))
 	{
-		Bit_Set(YSI_g_sPlayerProperties[playerid], cp, 0, GROUP_PROPERTY_BITS);
+		Bit_Set(YSI_g_sPlayerProperties[playerid], cp, false);//, GROUP_PROPERTY_BITS);
 	}
 	return 1;
 }
@@ -1988,12 +1999,13 @@ YCMD:buy(playerid, params[], help)
  * </remarks>
  *//*------------------------------------------------------------------------**/
 
-public Property_ResetRebuy(prop)
+forward Property_ResetRebuy(property);
+public Property_ResetRebuy(property)
 {
-	if (Property_IsActive(prop))
+	if (Property_IsActive(property))
 	{
 		new
-			e_PROP_FLAGS:flag = YSI_g_sProperties[prop][E_PROP_DATA_FLAGS];
+			e_PROP_FLAGS:flag = YSI_g_sProperties[property][E_PROP_DATA_FLAGS];
 		if ((flag & e_PROP_FLAGS_TYPES) == e_PROP_FLAGS_TYPE_PROP)
 		{
 			#pragma tabsize 4
@@ -2069,17 +2081,17 @@ ptask Property_Loop[500](i)
 			if (props & slot)
 			{
 				new
-					prop = (j * 32) + bit,
-					flags = YSI_g_sProperties[prop][E_PROP_DATA_FLAGS];
+					property = (j * 32) + bit,
+					flags = YSI_g_sProperties[property][E_PROP_DATA_FLAGS];
 				if (flags & _:e_PROP_FLAGS_ACTIVE)
 				{
 					switch (flags & _:e_PROP_FLAGS_TYPES)
 					{
 						case e_PROP_FLAGS_TYPE_MONP, e_PROP_FLAGS_TYPE_MONA:
-							if (!YSI_g_sProperties[prop][E_PROP_DATA_DATA_2]) GivePlayerMoney(i, YSI_g_sProperties[prop][E_PROP_DATA_DATA_1]);
+							if (!YSI_g_sProperties[property][E_PROP_DATA_DATA_2]) GivePlayerMoney(i, YSI_g_sProperties[property][E_PROP_DATA_DATA_1]);
 						case e_PROP_FLAGS_TYPE_PROP:
 						{
-							if (((Property_GetOption(2, flags)) ? (_:Bit_GetBit(YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS], i)) : (_:(YSI_g_sProperties[prop][E_PROP_DATA_PLAYERS][0] == Bit:i))) && !YSI_g_sProperties[prop][E_PROP_DATA_NAME][MAX_PROP_NAME - 1]) money += YSI_g_sProperties[prop][E_PROP_DATA_DATA_2] & 0x3FFFF;
+							if (((Property_GetOption(2, flags)) ? (_:Bit_GetBit(YSI_g_sProperties[property][E_PROP_DATA_PLAYERS], i)) : (_:(YSI_g_sProperties[property][E_PROP_DATA_PLAYERS][0] == Bit:i))) && !YSI_g_sProperties[property][E_PROP_DATA_NAME][MAX_PROP_NAME - 1]) money += YSI_g_sProperties[property][E_PROP_DATA_DATA_2] & 0x3FFFF;
 						}
 						case e_PROP_FLAGS_TYPE_RSRC:
 						{
@@ -2092,7 +2104,7 @@ ptask Property_Loop[500](i)
 							{
 								new Float:health;
 								GetPlayerHealth(i, health);
-								SetPlayerHealth(i, health - YSI_g_sProperties[prop][E_PROP_DATA_DATA_2]);
+								SetPlayerHealth(i, health - YSI_g_sProperties[property][E_PROP_DATA_DATA_2]);
 							}
 						}
 					}
@@ -2105,7 +2117,7 @@ ptask Property_Loop[500](i)
 	}
 	if (money)
 	{
-		Text_SendFormat(i, "YSI_PROP_EARNT", money);
+		Text_Send(i, $YSI_PROP_EARNT, money);
 		GivePlayerMoney(i, money);
 	}
 	if (!bad) GetPlayerPos(i, s_fLastGoodPos[i][0], s_fLastGoodPos[i][1], s_fLastGoodPos[i][2]);


### PR DESCRIPTION
I tested every include, attempted to fix a few but there are still issues remaining.

**Errors/warnings that need to be fixed:**
```Pawn
YSI_Players\y_text\y_text_render.inc(760) : warning 214: possibly a "const" array argument was intended: "out"
YSI_Players\y_text\y_text_render.inc(775) : warning 214: possibly a "const" array argument was intended: "out"
```
`Format_DoDisplay` modifies `out` array. Adding `const` to the same function with different states will give:
**YSI_Players\y_text\y_text_render.inc(787) : error 025: function heading differs from prototype**
It is a bug related to different states reported a while ago.

```Pawn
YSI_Players\y_text\y_text_impl.inc(335) : warning 209: function "Jagged_UnsafeResizeOne" should return a value
YSI_Players\y_text\y_text_impl.inc(358) : warning 209: function "Jagged_UnsafeResizeOne" should return a value
YSI_Players\y_text\y_text_impl.inc(369) : warning 209: function "Jagged_UnsafeResizeOne" should return a value
YSI_Players\y_text\y_text_impl.inc(398) : warning 209: function "Jagged_UnsafeResizeOne" should return a value
YSI_Players\y_text\y_text_impl.inc(409) : warning 209: function "Jagged_UnsafeResizeOne" should return a value
```
```Pawn
YSI_Visual\y_races\y_races_impl.inc(885) : warning 239: literal array/string passed to a non-const parameter
YSI_Visual\y_races\y_races_impl.inc(890) : warning 239: literal array/string passed to a non-const parameter
```
```Pawn
YSI_Visual\y_zonenames\y_zonenames_entry.inc(138) : warning 239: literal array/string passed to a non-const parameter
```
```Pawn
YSI_Storage\y_svar\y_svar_ini.inc(122) : error 017: undefined symbol "INI_WriteArray"
```
`INI_WriteArray` was removed completely from y_ini? 
```Pawn
YSI_Visual\y_properties\y_properties_entry.inc(190) : error 010: invalid function or declaration
YSI_Visual\y_properties\y_properties_entry.inc(319) : error 021: symbol already defined: "@yH_OnScriptInit@015"
YSI_Visual\y_properties\y_properties_entry.inc(964) : error 017: undefined symbol "Checkpoint_SetVisible"
YSI_Visual\y_properties\y_properties_entry.inc(2017) : error 017: undefined symbol "Checkpoint_SetVisible"
YSI_Visual\y_properties\y_properties_entry.inc(2120) : error 029: invalid expression, assumed zero
YSI_Visual\y_properties\y_properties_entry.inc(2120) : error 017: undefined symbol "YSI_PROP_EARNT"
YSI_Visual\y_properties\y_properties_entry.inc(2120) : error 029: invalid expression, assumed zero
YSI_Visual\y_properties\y_properties_entry.inc(2120) : fatal error 107: too many error messages on one line
```
```Pawn
YSI_Players\y_groups\y_groups_impl.inc(156) : warning 239: literal array/string passed to a non-const parameter
YSI_Players\y_groups\y_groups_impl.inc(157) : warning 239: literal array/string passed to a non-const parameter
```
```Pawn
YSI_Visual\y_commands\y_commands_impl.inc(145) : warning 239: literal array/string passed to a non-const parameter
YSI_Visual\y_commands\y_commands_impl.inc(146) : warning 239: literal array/string passed to a non-const parameter
YSI_Visual\y_commands\y_commands_impl.inc(148) : warning 239: literal array/string passed to a non-const parameter
YSI_Visual\y_commands\y_commands_impl.inc(158) : warning 239: literal array/string passed to a non-const parameter
```

`y_properties` (checkpoints) and `y_text` are incomplete.
`y_users` and `y_uvar` give **fatal error 111: user error: Default hash removed: See YSI topic for details.** when including them.